### PR TITLE
Accessing `window.sessionStorage` throws an exception "Operation is not ...

### DIFF
--- a/src/jquery.browser-fingerprint-1.1.js
+++ b/src/jquery.browser-fingerprint-1.1.js
@@ -45,7 +45,6 @@
         navigator.userAgent,
         [ screen.height, screen.width, screen.colorDepth ].join("x"),
         ( new Date() ).getTimezoneOffset(),
-        !!window.sessionStorage,
         !!window.localStorage,
         $.map( navigator.plugins, function(p) {
           return [


### PR DESCRIPTION
...supported" in Firefox 12.0.
